### PR TITLE
Save and load 'ids_processed' using an absolute path

### DIFF
--- a/typeform-ipb-import.php
+++ b/typeform-ipb-import.php
@@ -171,7 +171,7 @@ function postApplications($formData) {
  */
 function updateLatestId($id) {
 	$line = "$id\n";
-	file_put_contents('ids_processed', $line, FILE_APPEND | LOCK_EX);
+	file_put_contents(__DIR__ . '/ids_processed', $line, FILE_APPEND | LOCK_EX);
 }
 
 /**
@@ -183,7 +183,7 @@ function updateLatestId($id) {
  */
 function getLatestId() {
 	global $config;
-	$log = file_get_contents('ids_processed');
+	$log = file_get_contents(__DIR__ . '/ids_processed');
 
 	if (!$log) {
 		$id = $config['typeform']['latestId'];


### PR DESCRIPTION
Was having a problem in which cronjobs were failing to run this and kept getting permission denied. This was down to the fact that they don't really have a working directory, so I'm assuming it defaults to the root `/` folder which only the root user has write permission to.
