### PR TITLE
Fixed invalid hashbang

### DIFF
--- a/typeform-ipb-import.php
+++ b/typeform-ipb-import.php
@@ -1,4 +1,4 @@
-#!/usr/bin/env/php
+#!/usr/bin/env php
 <?php
 
 require 'vendor/autoload.php';


### PR DESCRIPTION
`/usr/bin/env/php` doesn't exist, `/usr/bin/env php` is the correct way to load it. (Alternative is `/usr/bin/php` but env is the preferable way)
